### PR TITLE
Force encoding to be utf-8 when loading from file

### DIFF
--- a/pyconll/load.py
+++ b/pyconll/load.py
@@ -109,7 +109,7 @@ def iter_from_file(filename):
         IOError if there is an error opening the file.
         ParseError: If there is an error parsing the input into a Conll object.
     """
-    with open(filename) as f:
+    with open(filename, encoding='utf-8') as f:
         for sentence in iter_sentences(f):
             yield sentence
 

--- a/pyconll/load.py
+++ b/pyconll/load.py
@@ -43,7 +43,7 @@ def load_from_file(filename):
         IOError: If there is an error opening the given filename.
         ParseError: If there is an error parsing the input into a Conll object.
     """
-    with open(filename) as f:
+    with open(filename, encoding='utf-8') as f:
         c = Conll(f)
 
     return c


### PR DESCRIPTION
Current version on my machine tries to use another encoding and fails. Tested this change, that fixes that issue.