### PR TITLE
Fix underscore parsing

### DIFF
--- a/pyconll/unit/token.py
+++ b/pyconll/unit/token.py
@@ -547,7 +547,7 @@ class Token(Conllable):
     V_DEPS_DELIMITER = ':'
     EMPTY = '_'
 
-    def __init__(self, source, empty=True, _line_number=None):
+    def __init__(self, source, empty=False, _line_number=None):
         """
         Construct the token from the given source.
 
@@ -602,7 +602,7 @@ class Token(Conllable):
         if empty or (fields[1] != Token.EMPTY or fields[2] != Token.EMPTY):
             self._form = _unit_empty_map(fields[1], Token.EMPTY)
             self.lemma = _unit_empty_map(fields[2], Token.EMPTY)
-        elif fields[1] == Token.EMPTY and fields[2] == Token.EMPTY:
+        else:
             self._form = fields[1]
             self.lemma = fields[2]
 

--- a/tests/unit/test_token.py
+++ b/tests/unit/test_token.py
@@ -174,7 +174,7 @@ def test_underscore_construction():
     Test construction of token without empty assumption and no form or lemma.
     """
     token_line = '33	_	_	PUN	_	_	30	nmod	_	SpaceAfter=No'
-    token = Token(token_line, empty=False)
+    token = Token(token_line)
 
     assert_token_members(token, '33', '_', '_', 'PUN', None, {}, '30', 'nmod',
                          {}, {'SpaceAfter': set(('No', ))})
@@ -185,7 +185,7 @@ def test_empty_form_present_lemma():
     Test construction of token without empty assumption and no form but a present lemma.
     """
     token_line = '33	hate	_	VERB	_	_	30	nmod	_	SpaceAfter=No'
-    token = Token(token_line, empty=False)
+    token = Token(token_line)
 
     assert_token_members(token, '33', 'hate', None, 'VERB', None, {}, '30',
                          'nmod', {}, {'SpaceAfter': set(('No', ))})
@@ -196,10 +196,21 @@ def test_empty_lemma_present_form():
     Test construction of token without empty assumption and no lemma but a present form.
     """
     token_line = '33	_	hate	VERB	_	_	30	nmod	_	SpaceAfter=No'
-    token = Token(token_line, empty=False)
+    token = Token(token_line)
 
     assert_token_members(token, '33', None, 'hate', 'VERB', None, {}, '30',
                          'nmod', {}, {'SpaceAfter': set(('No', ))})
+
+
+def test_empty_lemma_empty_form_with_assumption():
+    """
+    Test that a Token with no form or lemma  with the empty assumption gets values of None.
+    """
+    token_line = '33	_	_	SYM	_	_	30	punct	_	SpaceAfter=No'
+    token = Token(token_line, empty=True)
+
+    assert_token_members(token, '33', None, None, 'SYM', None, {}, '30',
+                         'punct', {}, {'SpaceAfter': set(('No', ))})
 
 
 def test_improper_source():


### PR DESCRIPTION
Per #37 the underscore parsing is not entirely intuitive, as the previous assumption set a flag which assumed that all `_`s were `None`. This assumption has been changed along with unit tests changes.