### PR TITLE
Projectivity Addition

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -520,7 +520,7 @@ max-bool-expr=5
 max-branches=12
 
 # Maximum number of locals for function / method body.
-max-locals=15
+max-locals=25
 
 # Maximum number of parents for a class (see R0901).
 max-parents=10

--- a/pyconll/util.py
+++ b/pyconll/util.py
@@ -82,20 +82,16 @@ def find_nonprojective_deps(sentence):
         An iterable of pairs which represent the children of a nonprojective
         dependency pair.
     """
-    non_root_tokens = filter(lambda token: token.head != '0', sentence)
-    deps = list(map(_token_to_dep_tuple, non_root_tokens))
-    sorted_deps = sorted(deps, key=_DependencyComparer)
-
+    deps = _transform_tokens_to_sorted_dependency_arcs(sentence)
     non_projective_deps = []
 
-    openings = [_IndexComparer('0')]
-    closings = [_IndexComparer(str(len(sentence)))]
+    openings = [-math.inf]
+    closings = [math.inf]
     direcs = ['']
 
-    for dep in sorted_deps:
+    for dep in deps:
         cur_opening = openings[-1]
         cur_closing = closings[-1]
-        cur_direc = direcs[-1]
 
         left_index, right_index, direc = dep
 
@@ -124,128 +120,106 @@ def find_nonprojective_deps(sentence):
             closings.append(right_index)
             direcs.append(direc)
 
-    child_tokens = list(map(lambda dep: tuple(map(lambda wrp: sentence[wrp.index], dep)), non_projective_deps))
+    child_tokens = list(
+        map(lambda dep: tuple(map(lambda idx: sentence[idx], dep)),
+            non_projective_deps))
     return child_tokens
 
 
-def _dep_to_token_pair(sentence, dep):
+def _transform_tokens_to_sorted_dependency_arcs(sentence):
     """
-    """
-    head_idx = dep[0] if dep[2] == 'l' else dep[1]
-    child_idx = dep[1] if dep[2] == 'l' else dep[0]
+    Transforms a given sentence or set of tokens into dependency arcs.
 
-    return (sentence[head_idx], sentence[child_idx])
+    These dependency arcs are tuples which consist of a head id, a token id and
+    head direction. These dependencies are sorted to facilitate non-projectivity
+    detection.
+
+    Args:
+        sentence: The tokens to transform to dependency arcs.
+
+    Returns:
+        The sorted list of dependency arcs extracted from the sentence.
+    """
+    # Create a string token id to numeric index map for the sentence.
+    ids_to_idxs = {token.id: i for i, token in enumerate(sentence)}
+
+    dependency_tokens = filter(
+        lambda token: token.head != '0' and not token.is_multiword(), sentence)
+    deps = sorted(
+        map(lambda token: _token_to_dep_tuple(token, ids_to_idxs),
+            dependency_tokens),
+        key=_DependencyComparer)
+
+    return deps
 
 
 @functools.total_ordering
 class _DependencyComparer:
     """
+    Wrapper to compare dependency arcs.
     """
 
     def __init__(self, dep):
         """
+        Creates the wrapper for this dependency.
+
+        Args:
+            dep: The dependency to wrap.
         """
         self._l, self._r, _ = dep
 
     def __eq__(self, other):
         """
+        Checks that this dependency has the same indices as another.
+
+        Args:
+            other: The other wrapped dependency to compare against.
         """
         return self._l == other._l and self._r == other._r
 
     def __ne__(self, other):
         """
+        Checks that this dependency has different indices as another.
+
+        Args:
+            other: Another wrapped dependency to compare against.
         """
-        return not (self == other)
+        return not self == other
 
     def __lt__(self, other):
         """
+        Checks that this dependency is less than another.
+
+        This comparison is done by first checking the smaller of the two
+        indices. The second indices are compared if the first are equal and this
+        dependency will be smaller if its second index is larger.
+
+        Args:
+            other: Another wrapped dependency to compare against.
         """
         return self._l < other._l or (self._l == other._l
                                       and self._r > other._r)
 
 
-@functools.total_ordering
-class _IndexComparer:
-    """
-    """
-
-    def __init__(self, index):
-        """
-        """
-        self.index = index
-
-    def __eq__(self, other):
-        """
-        """
-        return self.index == other.index
-
-    def __ne__(self, other):
-        return not (self == other)
-
-    def __lt__(self, other):
-        """
-        """
-        ((self_fh, self_fp), (self_sh, self_sp)) = _IndexComparer._separate_index(self.index)
-        ((other_fh, other_fp), (other_sh, other_sp)) = _IndexComparer._separate_index(other.index)
-
-        f = self_fh < other_fh or (self_fh == other_fh and self_fp < other_fp)
-        fe = self_fh == other_fh and self_fp == other_fp
-        s = self_sh < other_sh or (self_sh == other_sh and self_sp < other_sp)
-
-        # Either the first element is less or they are equal and the second is less.
-        return f or (fe and s)
-
-    @staticmethod
-    def _separate_index(index):
-        """
-        """
-        if '-' in index:
-            sep_idx = index.index('-')
-            first = index[:sep_idx]
-            second = index[sep_idx + 1:]
-
-            if '.' in first:
-                dot_idx = first.index('.')
-                fh = int(first[:dot_idx])
-                fp = int(first[dot_idx + 1:])
-            else:
-                fh = int(first)
-                fp = -math.inf
-
-            if '.' in second:
-                dot_idx = second.index('.')
-                sh = int(second[:dot_idx])
-                sp = int(second[dot_idx + 1:])
-            else:
-                sh = int(second)
-                sp = -math.inf
-        else:
-            fh = int(index)
-            fp = -math.inf
-            sh = -math.inf
-            sp = -math.inf
-
-        return ((fh, fp), (sh, sp))
-
-
-def _token_to_dep_tuple(token):
+def _token_to_dep_tuple(token, id_map):
     """
     Creates a tuple of primitives to represent the dependency on a token.
 
     Args:
         token: The token to convert to a tupled dependency representation.
+        id_map: A mapping from string token ids to indices.
 
     Returns:
         A triplet where the first element is the minimum of the token id and
         governor id, the second is the maximum, and the third is the direction
         of the dependency.
     """
-    id_i = _IndexComparer(token.id)
-    head_i = _IndexComparer(token.head)
-    if id_i < head_i:
-        return (id_i, head_i, 'r')
-    else:
-        return (head_i, id_i, 'l')
+    token_idx = id_map[token.id]
+    head_idx = id_map[token.head]
+    if token_idx < head_idx:
+        return (token_idx, head_idx, 'r')
+
+    return (head_idx, token_idx, 'l')
 
 
 def _get_cased(case_sensitive, *args):
@@ -258,7 +232,7 @@ def _get_cased(case_sensitive, *args):
         args: The strings to get appropriately cased versions of.
 
     Returns:
-        An iterable  of case converted strings as necessary.
+        An iterable of case converted strings as necessary.
     """
     if not case_sensitive:
         args = list(map(str.lower, args))

--- a/pyconll/util.py
+++ b/pyconll/util.py
@@ -75,6 +75,12 @@ def find_nonprojective_deps(sentence):
     """
     Find the nonprojective dependency pairs in the provided sentence.
 
+    Dependencies are provided as a list of ordered pairs. Each ordered pair
+    represents a non-projective dependency pair. Each element in the ordered
+    pair is a token, that makes a dependency with its governor. So each token
+    is the base of its dependency, and the two tokens' dependencies cross in
+    a non projective way.
+
     Args:
         sentence: The sentence to check for nonprojective dependency pairs.
 

--- a/tests/fixtures/projectivities.conll
+++ b/tests/fixtures/projectivities.conll
@@ -1,0 +1,62 @@
+# sent_id = fr-ud-test_00001
+# text = Je sens qu'entre ça et les films de médecins et scientifiques fous que nous avons déjà vus, nous pourrions emprunter un autre chemin pour l'origine.
+1	Je	il	PRON	_	Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
+2	sens	sentir	VERB	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
+3	qu'	que	SCONJ	_	_	21	mark	_	SpaceAfter=No
+4	entre	entre	ADP	_	_	5	case	_	_
+5	ça	ça	PRON	_	Gender=Masc|Number=Sing|Person=3|PronType=Dem	21	obl:mod	_	_
+6	et	et	CCONJ	_	_	8	cc	_	_
+7	les	le	DET	_	Definite=Def|Gender=Masc|Number=Plur|PronType=Art	8	det	_	_
+8	films	film	NOUN	_	Gender=Masc|Number=Plur	5	conj	_	_
+9	de	de	ADP	_	_	10	case	_	_
+10	médecins	médecin	NOUN	_	Gender=Masc|Number=Plur	8	nmod	_	_
+11	et	et	CCONJ	_	_	12	cc	_	_
+12	scientifiques	scientifique	NOUN	_	Gender=Masc|Number=Plur	10	conj	_	_
+13	fous	fou	ADJ	_	Gender=Masc|Number=Plur	12	amod	_	_
+14	que	que	PRON	_	PronType=Rel	18	obj	_	_
+15	nous	nous	PRON	_	Number=Plur|Person=1|PronType=Prs	18	nsubj	_	_
+16	avons	avoir	AUX	_	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	18	aux	_	_
+17	déjà	déjà	ADV	_	_	18	advmod	_	_
+18	vus	voir	VERB	_	Gender=Masc|Number=Plur|Tense=Past|VerbForm=Part	8	acl:relcl	_	SpaceAfter=No
+19	,	,	PUNCT	_	_	5	punct	_	_
+20	nous	nous	PRON	_	Number=Plur|Person=1|PronType=Prs	21	nsubj	_	_
+21	pourrions	pouvoir	VERB	_	Mood=Cnd|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	2	ccomp	_	_
+22	emprunter	emprunter	VERB	_	VerbForm=Inf	21	xcomp	_	_
+23	un	un	DET	_	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	25	det	_	_
+24	autre	autre	ADJ	_	Gender=Masc|Number=Sing	25	amod	_	_
+25	chemin	chemin	NOUN	_	Gender=Masc|Number=Sing	22	obj	_	_
+26	pour	pour	ADP	_	_	28	case	_	_
+27	l'	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	28	det	_	SpaceAfter=No
+28	origine	origine	NOUN	_	Gender=Fem|Number=Sing	22	obl	_	SpaceAfter=No
+29	.	.	PUNCT	_	_	2	punct	_	_
+
+# sent_id = fr-ud-test_00002
+# text = On pourra toujours parler à propos d'Averroès de "décentrement du Sujet".
+1	On	on	PRON	_	Gender=Masc|Number=Sing|Person=3	2	nsubj	_	_
+2	pourra	pouvoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Fut|VerbForm=Fin	0	root	_	_
+3	toujours	toujours	ADV	_	_	2	advmod	_	_
+4	parler	parler	VERB	_	VerbForm=Inf	2	xcomp	_	_
+5	à	à	ADP	_	_	8	case	_	_
+6	propos	propos	NOUN	_	Gender=Masc|Number=Sing	5	fixed	_	_
+7	d'	de	ADP	_	_	5	fixed	_	SpaceAfter=No
+8	Averroès	Averroès	PROPN	_	_	4	obl	_	_
+9	de	de	ADP	_	_	11	case	_	_
+10	"	"	PUNCT	_	_	11	punct	_	SpaceAfter=No
+11	décentrement	décentrement	NOUN	_	Gender=Masc|Number=Sing	8	nmod	_	_
+12	de	de	ADP	_	_	14	case	_	_
+13	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
+14	Sujet	sujet	NOUN	_	Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
+15	"	"	PUNCT	_	_	11	punct	_	SpaceAfter=No
+16	.	.	PUNCT	_	_	3	punct	_	_
+
+# sent_id = en-ud-test_00003
+# text = John saw a dog yesterday which was happy.
+1	John	John	PROPN	_	_	2	nsubj	_	_
+2	saw	see	VERB	_	_	0	root	_	_
+3	a	a	DET	_	_	4	det	_	_
+4	dog	dog	NOUN	_	_	2	obj	_	_
+5	yesterday	yesterday	ADV	_	_	2	advmod	_	_
+6	which	which	PRON	_	_	8	nsubj	_	_
+7	was	be	AUX	_	_	8	cop	_	_
+8	happy	happy	ADJ	_	_	4	acl	_	_
+9	.	.	PUNCT	_	_	2	punct	_	_

--- a/tests/fixtures/projectivities.conll
+++ b/tests/fixtures/projectivities.conll
@@ -60,3 +60,42 @@
 7	was	be	AUX	_	_	8	cop	_	_
 8	happy	happy	ADJ	_	_	4	acl	_	_
 9	.	.	PUNCT	_	_	2	punct	_	_
+
+# sent_id = fr-ud-test_00004
+# text = On pourra toujours parler à propos d'Averroès de "décentrement du Sujet".
+1	On	on	PRON	_	Gender=Masc|Number=Sing|Person=3	2	nsubj	_	_
+2	pourra	pouvoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Fut|VerbForm=Fin	0	root	_	_
+3	toujours	toujours	ADV	_	_	2	advmod	_	_
+4	parler	parler	VERB	_	VerbForm=Inf	2	xcomp	_	_
+5	à	à	ADP	_	_	8	case	_	_
+6	propos	propos	NOUN	_	Gender=Masc|Number=Sing	5	fixed	_	_
+7	d'	de	ADP	_	_	5	fixed	_	SpaceAfter=No
+8	Averroès	Averroès	PROPN	_	_	4	obl	_	_
+9	de	de	ADP	_	_	11	case	_	_
+10	"	"	PUNCT	_	_	11	punct	_	SpaceAfter=No
+11	décentrement	décentrement	NOUN	_	Gender=Masc|Number=Sing	8	nmod	_	_
+12-13	du	_	_	_	_	_	_	_	_
+12	de	de	ADP	_	_	14	case	_	_
+13	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
+14	Sujet	sujet	NOUN	_	Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
+15	"	"	PUNCT	_	_	11	punct	_	SpaceAfter=No
+16	.	.	PUNCT	_	_	3	punct	_	_
+
+# sent_id = fr-ud-test_00005
+# text = On pourra toujours parler à propos d'Averroès de "décentrement du Sujet".
+1	On	on	PRON	_	Gender=Masc|Number=Sing|Person=3	2	nsubj	_	_
+2	pourra	pouvoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Fut|VerbForm=Fin	0	root	_	_
+3	toujours	toujours	ADV	_	_	2	advmod	_	_
+4	parler	parler	VERB	_	VerbForm=Inf	2	xcomp	_	_
+5	à	à	ADP	_	_	8	case	_	_
+6	propos	propos	NOUN	_	Gender=Masc|Number=Sing	5	fixed	_	_
+7	d'	de	ADP	_	_	5	fixed	_	SpaceAfter=No
+8	Averroès	Averroès	PROPN	_	_	4	obl	_	_
+9	de	de	ADP	_	_	11	case	_	_
+10	"	"	PUNCT	_	_	11	punct	_	SpaceAfter=No
+11	décentrement	décentrement	NOUN	_	Gender=Masc|Number=Sing	2	nmod	_	_
+12	de	de	ADP	_	_	14	case	_	_
+13	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
+14	Sujet	sujet	NOUN	_	Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
+15	"	"	PUNCT	_	_	11	punct	_	SpaceAfter=No
+16	.	.	PUNCT	_	_	3	punct	_	_

--- a/tests/fixtures/projectivities.conll
+++ b/tests/fixtures/projectivities.conll
@@ -99,3 +99,35 @@
 14	Sujet	sujet	NOUN	_	Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
 15	"	"	PUNCT	_	_	11	punct	_	SpaceAfter=No
 16	.	.	PUNCT	_	_	3	punct	_	_
+
+# sent_id = fr-ud-test_00006
+# text = Je sens qu'entre ça et les films de médecins et scientifiques fous que nous avons déjà vus, nous pourrions emprunter un autre chemin pour l'origine.
+1	Je	il	PRON	_	Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
+2	sens	sentir	VERB	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
+3	qu'	que	SCONJ	_	_	21	mark	_	SpaceAfter=No
+4	entre	entre	ADP	_	_	5	case	_	_
+5	ça	ça	PRON	_	Gender=Masc|Number=Sing|Person=3|PronType=Dem	21	obl:mod	_	_
+6	et	et	CCONJ	_	_	8	cc	_	_
+7	les	le	DET	_	Definite=Def|Gender=Masc|Number=Plur|PronType=Art	8	det	_	_
+8	films	film	NOUN	_	Gender=Masc|Number=Plur	5	conj	_	_
+9	de	de	ADP	_	_	10	case	_	_
+10	médecins	médecin	NOUN	_	Gender=Masc|Number=Plur	8	nmod	_	_
+11	et	et	CCONJ	_	_	12	cc	_	_
+12	scientifiques	scientifique	NOUN	_	Gender=Masc|Number=Plur	10	conj	_	_
+13	fous	fou	ADJ	_	Gender=Masc|Number=Plur	12	amod	_	_
+14	que	que	PRON	_	PronType=Rel	18	obj	_	_
+15	nous	nous	PRON	_	Number=Plur|Person=1|PronType=Prs	18	nsubj	_	_
+16	avons	avoir	AUX	_	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	18	aux	_	_
+17	déjà	déjà	ADV	_	_	18	advmod	_	_
+18	vus	voir	VERB	_	Gender=Masc|Number=Plur|Tense=Past|VerbForm=Part	8	acl:relcl	_	SpaceAfter=No
+19	,	,	PUNCT	_	_	5	punct	_	_
+20	nous	nous	PRON	_	Number=Plur|Person=1|PronType=Prs	21	nsubj	_	_
+21	pourrions	pouvoir	VERB	_	Mood=Cnd|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	2	ccomp	_	_
+22	emprunter	emprunter	VERB	_	VerbForm=Inf	5	xcomp	_	_
+23	un	un	DET	_	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	25	det	_	_
+24	autre	autre	ADJ	_	Gender=Masc|Number=Sing	25	amod	_	_
+25	chemin	chemin	NOUN	_	Gender=Masc|Number=Sing	22	obj	_	_
+26	pour	pour	ADP	_	_	28	case	_	_
+27	l'	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	28	det	_	SpaceAfter=No
+28	origine	origine	NOUN	_	Gender=Fem|Number=Sing	23	obl	_	SpaceAfter=No
+29	.	.	PUNCT	_	_	2	punct	_	_

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -159,3 +159,51 @@ def test_simple_nonprojectivities():
 
     assert deps1 == [(sent1['16'], sent1['4'])]
     assert deps2 == [(sent2['8'], sent2['5'])]
+
+
+def test_multiword_ignore():
+    """
+    Test that multiword tokens are ignored and do not cause errors.
+    """
+    c = load_from_file(fixture_location('projectivities.conll'))
+
+    sent = c[3]
+    deps = find_nonprojective_deps(sent)
+
+    assert deps == [(sent['16'], sent['4'])]
+
+
+def test_overlapping_nonprojectivities():
+    """
+    Test that multiple non-projectivities can overlap.
+    """
+    c = load_from_file(fixture_location('projectivities.conll'))
+
+    sent = c[4]
+    deps = find_nonprojective_deps(sent)
+
+    assert set(deps) == set([(sent['16'], sent['4']), (sent['16'],
+                                                       sent['11'])])
+
+
+def test_multiple_nonprojectivities():
+    pass
+
+
+def test_splitting_from_same_orgigin_nonprojectivity():
+    pass
+
+
+def test_simple_nonprojectivities():
+    """
+    Test logic with a sentence with one single non-projectivity.
+    """
+    c = load_from_file(fixture_location('projectivities.conll'))
+    sent1 = c[3]
+    deps1 = find_nonprojective_deps(sent1)
+
+    sent2 = c[2]
+    deps2 = find_nonprojective_deps(sent2)
+
+    assert deps1 == [(sent1['16'], sent1['4'])]
+    assert deps2 == [(sent2['8'], sent2['5'])]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -187,11 +187,16 @@ def test_overlapping_nonprojectivities():
 
 
 def test_multiple_nonprojectivities():
-    pass
+    """
+    Test that multiple disjoint projectivities are properly identified.
+    """
+    c = load_from_file(fixture_location('projectivities.conll'))
 
+    sent = c[5]
+    deps = find_nonprojective_deps(sent)
 
-def test_splitting_from_same_orgigin_nonprojectivity():
-    pass
+    assert set(deps) == set([(sent['22'], sent['3']), (sent['22'], sent['21']),
+                             (sent['28'], sent['25'])])
 
 
 def test_simple_nonprojectivities():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,7 @@ import operator
 
 import pytest
 
-from pyconll.util import find_ngrams
+from pyconll.util import find_ngrams, find_nonprojective_deps
 from pyconll import load_from_file
 from tests.util import fixture_location
 
@@ -133,3 +133,29 @@ def test_ngram_case_insensitive_n_token():
     assert s.id == 'fr-ud-test_00004'
     assert i == 8
     assert actual_token_ids == expected_token_ids
+
+
+def test_no_nonprojectivities():
+    """
+    Test with a sentence with no non-projective dependencies.
+    """
+    c = load_from_file(fixture_location('projectivities.conll'))
+    sent = c[0]
+    deps = find_nonprojective_deps(sent)
+
+    assert not deps
+
+
+def test_simple_nonprojectivities():
+    """
+    Test logic with a sentence with one single non-projectivity.
+    """
+    c = load_from_file(fixture_location('projectivities.conll'))
+    sent1 = c[1]
+    deps1 = find_nonprojective_deps(sent1)
+
+    sent2 = c[2]
+    deps2 = find_nonprojective_deps(sent2)
+
+    assert deps1 == [(sent1['16'], sent1['4'])]
+    assert deps2 == [(sent2['8'], sent2['5'])]


### PR DESCRIPTION
Add projectivity checks to the utility package. This function will return a list of dependencies (in the form of tokens). The token objects are the base of the dependency, i.e. the dependency is from the token to its governor.

The goal is help researchers have an easy way to do this computation baked into a libraries extended functionality to not have to go through the implementation task themselves.