### PR TITLE
Setting and removing metadata 

### DIFF
--- a/pyconll/unit/sentence.py
+++ b/pyconll/unit/sentence.py
@@ -159,9 +159,16 @@ class Sentence(Conllable):
                 singleton, this field can be ignored or set to None.
         """
         if self.meta_present(key):
-            raise ValueError('Key cannot be {}'.format(Sentence.TEXT_KEY))
+            raise ValueError('This key is already present.')
 
         self._meta[key] = value
+
+    def remove_meta(self, key):
+        """
+        Remove an element from metadata.
+        """
+
+        del self._meta[key]
 
     def to_tree(self):
         """
@@ -298,10 +305,3 @@ class Sentence(Conllable):
             includes both all the multiword tokens and their decompositions.
         """
         return len(self._tokens)
-
-    def remove_key(self, key):
-        """
-        Remove a key from metadata.
-        """
-
-        del self._meta[key]

--- a/pyconll/unit/sentence.py
+++ b/pyconll/unit/sentence.py
@@ -150,14 +150,15 @@ class Sentence(Conllable):
 
     def set_meta(self, key, value=None):
         """
-        Set the metadata or comments associated with this Sentence.
+        Set the metadata or comments associated with this Sentence. If key
+        present raises ValueError.
 
         Args:
             key: The key for the comment.
             value: The value to associate with the key. If the comment is a
                 singleton, this field can be ignored or set to None.
         """
-        if key == Sentence.TEXT_KEY:
+        if self.meta_present(key):
             raise ValueError('Key cannot be {}'.format(Sentence.TEXT_KEY))
 
         self._meta[key] = value
@@ -297,3 +298,10 @@ class Sentence(Conllable):
             includes both all the multiword tokens and their decompositions.
         """
         return len(self._tokens)
+
+    def remove_key(self, key):
+        """
+        Remove a key from metadata.
+        """
+
+        del self._meta[key]

--- a/pyconll/unit/sentence.py
+++ b/pyconll/unit/sentence.py
@@ -167,7 +167,6 @@ class Sentence(Conllable):
         """
         Remove an element from metadata.
         """
-
         del self._meta[key]
 
     def to_tree(self):

--- a/pyconll/unit/sentence.py
+++ b/pyconll/unit/sentence.py
@@ -150,7 +150,7 @@ class Sentence(Conllable):
 
     def set_meta(self, key, value=None):
         """
-        Set the metadata or comments associated with this Sentence. If key
+        Set the metadata or comments associated with this Sentence. If key is
         present raises ValueError.
 
         Args:


### PR DESCRIPTION
Hi! 

I just added one new method to delete metadata values (remove_meta) and changed the set_meta method for it to rise exceptions when the key is not empty, instead of not allowing users to change text data. 