### PR TITLE
Remove metadata from sentence

### DIFF
--- a/pyconll/unit/sentence.py
+++ b/pyconll/unit/sentence.py
@@ -159,9 +159,16 @@ class Sentence(Conllable):
                 singleton, this field can be ignored or set to None.
         """
         if self.meta_present(key):
-            raise ValueError('Key cannot be {}'.format(Sentence.TEXT_KEY))
+            raise ValueError('This key is already present.')
 
         self._meta[key] = value
+
+    def remove_meta(self, key):
+        """
+        Remove an element from metadata.
+        """
+
+        del self._meta[key]
 
     def to_tree(self):
         """
@@ -298,10 +305,3 @@ class Sentence(Conllable):
             includes both all the multiword tokens and their decompositions.
         """
         return len(self._tokens)
-
-    def remove_key(self, key):
-        """
-        Remove a key from metadata.
-        """
-
-        del self._meta[key]

--- a/pyconll/unit/sentence.py
+++ b/pyconll/unit/sentence.py
@@ -157,8 +157,8 @@ class Sentence(Conllable):
             value: The value to associate with the key. If the comment is a
                 singleton, this field can be ignored or set to None.
         """
-        if self.meta_present(key):
-            raise ValueError('This key is already present.')
+        if key == Sentence.TEXT_KEY:
+            raise ValueError('Key cannot be {}'.format(Sentence.TEXT_KEY))
 
         self._meta[key] = value
 

--- a/pyconll/unit/sentence.py
+++ b/pyconll/unit/sentence.py
@@ -165,8 +165,17 @@ class Sentence(Conllable):
 
     def remove_meta(self, key):
         """
-        Remove an element from metadata.
+        Remove a metadata element associated with the Sentence.
+
+        Args:
+            key: The name of the metadata / comment.
+
+        Raises:
+            KeyError: If the key is not present in the Sentence metadata.
         """
+        if key == Sentence.TEXT_KEY:
+            raise ValueError('Key cannot be {}'.format(Sentence.TEXT_KEY))
+
         del self._meta[key]
 
     def to_tree(self):

--- a/pyconll/unit/sentence.py
+++ b/pyconll/unit/sentence.py
@@ -150,14 +150,15 @@ class Sentence(Conllable):
 
     def set_meta(self, key, value=None):
         """
-        Set the metadata or comments associated with this Sentence.
+        Set the metadata or comments associated with this Sentence. If key
+        present raises ValueError.
 
         Args:
             key: The key for the comment.
             value: The value to associate with the key. If the comment is a
                 singleton, this field can be ignored or set to None.
         """
-        if key == Sentence.TEXT_KEY:
+        if self.meta_present(key):
             raise ValueError('Key cannot be {}'.format(Sentence.TEXT_KEY))
 
         self._meta[key] = value
@@ -297,3 +298,10 @@ class Sentence(Conllable):
             includes both all the multiword tokens and their decompositions.
         """
         return len(self._tokens)
+
+    def remove_key(self, key):
+        """
+        Remove a key from metadata.
+        """
+
+        del self._meta[key]

--- a/pyconll/unit/sentence.py
+++ b/pyconll/unit/sentence.py
@@ -167,7 +167,6 @@ class Sentence(Conllable):
         """
         Remove an element from metadata.
         """
-
         del self._meta[key]
 
     def to_tree(self):

--- a/pyconll/unit/sentence.py
+++ b/pyconll/unit/sentence.py
@@ -150,8 +150,7 @@ class Sentence(Conllable):
 
     def set_meta(self, key, value=None):
         """
-        Set the metadata or comments associated with this Sentence. If key is
-        present raises ValueError.
+        Set or add the metadata or comments associated with this Sentence.
 
         Args:
             key: The key for the comment.

--- a/pyconll/unit/sentence.py
+++ b/pyconll/unit/sentence.py
@@ -150,7 +150,7 @@ class Sentence(Conllable):
 
     def set_meta(self, key, value=None):
         """
-        Set the metadata or comments associated with this Sentence. If key
+        Set the metadata or comments associated with this Sentence. If key is
         present raises ValueError.
 
         Args:

--- a/tests/unit/test_sentence.py
+++ b/tests/unit/test_sentence.py
@@ -695,8 +695,8 @@ def test_change_comments():
 
 def test_add_comments():
     """
-    Test that comment values (other than text or id) can be added through the
-    meta api.
+    Test that comment values (other than text) can be added through the meta
+    api.
     """
     source = (
         '# sent_id = fr-ud-dev_00002\n'
@@ -739,6 +739,60 @@ def test_add_comments():
     sentence.set_meta('x-coord', '2')
 
     assert sentence.conll() == expected
+
+
+def test_remove_comments():
+    """
+    Test that comments can be removed from the sentence (other than text), and
+    removing non-existent comments throws a KeyError.
+    """
+    source = (
+        '# sent_id = fr-ud-dev_00002\n'
+        '# text = Les études durent six ans mais leur contenu diffère donc selon les Facultés.\n'
+        '# x-coord = 2\n'
+        '1	Les	le	DET	_	Definite=Def|Gender=Fem|Number=Plur|PronType=Art	2	det	_	_\n'
+        '2	études	étude	NOUN	_	Gender=Fem|Number=Plur	3	nsubj	_	_\n'
+        '3	durent	durer	VERB	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_\n'
+        '4	six	six	NUM	_	_	5	nummod	_	_\n'
+        '5	ans	an	NOUN	_	Gender=Masc|Number=Plur	3	obj	_	_\n'
+        '6	mais	mais	CCONJ	_	_	9	cc	_	_\n'
+        '7	leur	son	DET	_	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_\n'
+        '8	contenu	contenu	NOUN	_	Gender=Masc|Number=Sing	9	nsubj	_	_\n'
+        '9	diffère	différer	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	conj	_	_\n'
+        '10	donc	donc	ADV	_	_	9	advmod	_	_\n'
+        '11	selon	selon	ADP	_	_	13	case	_	_\n'
+        '12	les	le	DET	_	Definite=Def|Number=Plur|PronType=Art	13	det	_	_\n'
+        '13	Facultés	Facultés	PROPN	_	_	9	obl	_	SpaceAfter=No\n'
+        '14	.	.	PUNCT	_	_	3	punct	_	_')
+
+    expected = (
+        '# sent_id = fr-ud-dev_00002\n'
+        '# text = Les études durent six ans mais leur contenu diffère donc selon les Facultés.\n'
+        '1	Les	le	DET	_	Definite=Def|Gender=Fem|Number=Plur|PronType=Art	2	det	_	_\n'
+        '2	études	étude	NOUN	_	Gender=Fem|Number=Plur	3	nsubj	_	_\n'
+        '3	durent	durer	VERB	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_\n'
+        '4	six	six	NUM	_	_	5	nummod	_	_\n'
+        '5	ans	an	NOUN	_	Gender=Masc|Number=Plur	3	obj	_	_\n'
+        '6	mais	mais	CCONJ	_	_	9	cc	_	_\n'
+        '7	leur	son	DET	_	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_\n'
+        '8	contenu	contenu	NOUN	_	Gender=Masc|Number=Sing	9	nsubj	_	_\n'
+        '9	diffère	différer	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	conj	_	_\n'
+        '10	donc	donc	ADV	_	_	9	advmod	_	_\n'
+        '11	selon	selon	ADP	_	_	13	case	_	_\n'
+        '12	les	le	DET	_	Definite=Def|Number=Plur|PronType=Art	13	det	_	_\n'
+        '13	Facultés	Facultés	PROPN	_	_	9	obl	_	SpaceAfter=No\n'
+        '14	.	.	PUNCT	_	_	3	punct	_	_')
+
+    sentence = Sentence(source)
+    sentence.remove_meta('x-coord')
+
+    assert sentence.conll() == expected
+
+    with pytest.raises(ValueError):
+        sentence.remove_meta('text')
+
+    with pytest.raises(KeyError):
+        sentence.remove_meta('x-coord')
 
 
 def test_singleton_comment():


### PR DESCRIPTION
Remove metadata from sentence, and keep history intact.

Cf with #53 .