### PR TITLE
Fix syntax error for copyright string.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ _year = datetime.datetime.now().year
 
 project = 'pyconll'
 author = 'Matias Grioni'
-copyright = '{}, {}'.format(_year, _author)
+copyright = '{}, {}'.format(_year, author)
 
 # The short X.Y version
 _v = read('../.version').strip()


### PR DESCRIPTION
There was a syntax error in the doc generation script. This fixes the issue. Hoping to get RTD integration into the PR system and also should create a build script that will check that the build works locally before publishing (but those are separate for now).