### PR TITLE
Improve parse failure messages

### DIFF
--- a/pyconll/_parser.py
+++ b/pyconll/_parser.py
@@ -16,6 +16,8 @@ def _create_sentence(sent_lines: Iterable[str], line_num: int) -> Sentence:
 
     Args:
         sent_lines: An iterable of the lines that make up the source.
+        line_num: The current line number the sentence starts at, for logging
+            purposes.
 
     Returns:
         The created Sentence.

--- a/pyconll/unit/conll.py
+++ b/pyconll/unit/conll.py
@@ -39,6 +39,10 @@ class Conll(MutableSequence[Sentence], Conllable):
 
         Returns:
             The CoNLL-U object as a string. This string will end in a newline.
+
+        Raises:
+            FormatError: If there are issues converting the sentences to the
+                CoNLL format.
         """
         # Add newlines along with sentence strings so that there is no need to
         # slice potentially long lists or modify strings.

--- a/pyconll/unit/sentence.py
+++ b/pyconll/unit/sentence.py
@@ -7,7 +7,7 @@ import re
 from typing import ClassVar, Dict, Iterator, List, Optional, Sequence, overload
 
 from pyconll.conllable import Conllable
-from pyconll.exception import ParseError
+from pyconll.exception import FormatError, ParseError
 from pyconll.tree._treebuilder import TreeBuilder
 from pyconll.tree.tree import Tree
 from pyconll.unit.token import Token
@@ -274,6 +274,10 @@ class Sentence(Sequence[Token], Conllable):
 
         Returns:
             A string representing the Sentence in CoNLL-U format.
+
+        Raises:
+            FormatError: If the Sentence or underlying Tokens can not be
+                converted to the CoNLL format.
         """
         lines = []
         for meta in self._meta.items():
@@ -286,7 +290,12 @@ class Sentence(Sequence[Token], Conllable):
             lines.append(line)
 
         for token in self._tokens:
-            lines.append(token.conll())
+            try:
+                lines.append(token.conll())
+            except FormatError as err:
+                raise FormatError(
+                    'Error serializing sentence with id {} on token \'{}\'.'.
+                    format(self.id, token.id)) from err
 
         return '\n'.join(lines)
 

--- a/pyconll/unit/sentence.py
+++ b/pyconll/unit/sentence.py
@@ -7,6 +7,7 @@ import re
 from typing import ClassVar, Dict, Iterator, List, Optional, Sequence, overload
 
 from pyconll.conllable import Conllable
+from pyconll.exception import ParseError
 from pyconll.tree._treebuilder import TreeBuilder
 from pyconll.tree.tree import Tree
 from pyconll.unit.token import Token
@@ -64,7 +65,7 @@ class Sentence(Sequence[Token], Conllable):
         self._tokens: List[Token] = []
         self._ids_to_indexes: Dict[str, int] = {}
 
-        for line in lines:
+        for i, line in enumerate(lines):
             if line:
                 if line[0] == Sentence.COMMENT_MARKER:
                     kv_match = re.match(Sentence.KEY_VALUE_COMMENT_PATTERN,
@@ -81,7 +82,13 @@ class Sentence(Sequence[Token], Conllable):
                             k = singleton_match.group(1)
                             self._meta[k] = None
                 else:
-                    token = Token(line)
+                    try:
+                        token = Token(line)
+                    except ParseError as err:
+                        raise ParseError(
+                            'Error creating token on line {} for the current sentence'
+                            .format(i)) from err
+
                     self._tokens.append(token)
 
                     if token.id is not None:

--- a/pyconll/unit/token.py
+++ b/pyconll/unit/token.py
@@ -9,7 +9,7 @@ import math
 from typing import Callable, ClassVar, Dict, Optional, Set, Tuple
 
 from pyconll.conllable import Conllable
-from pyconll.exception import ParseError, FormatError
+from pyconll.exception import FormatError, ParseError
 
 
 def _unit_empty_map(value, empty):
@@ -735,6 +735,9 @@ class Token(Conllable):
 
         Returns:
             A string representing the Token in CoNLL-U format.
+
+        Raises:
+            FormatError: If the Token can not be converted to the CoNLL format.
         """
         # Transform the internal CoNLL-U representations back to text and
         # combine the fields.


### PR DESCRIPTION
Based on user feedback, introducing line numbers in error messages will be very useful for debugging and error tracking.